### PR TITLE
Update to the command to get the correct branch

### DIFF
--- a/Modules/admin/admin_main_view.php
+++ b/Modules/admin/admin_main_view.php
@@ -73,7 +73,7 @@
                  'mem_info' => $meminfo,
                  'partitions' => disk_list(),
                  'emoncms_modules' => $emoncms_modules,
-                 'git_branch' => @exec("git -C " . substr($_SERVER['SCRIPT_FILENAME'], 0, strrpos($_SERVER['SCRIPT_FILENAME'], '/')) . " branch"),
+                 'git_branch' => @exec("git -C " . substr($_SERVER['SCRIPT_FILENAME'], 0, strrpos($_SERVER['SCRIPT_FILENAME'], '/')) . " branch --contains HEAD"),
                  'git_URL' => @exec("git -C " . substr($_SERVER['SCRIPT_FILENAME'], 0, strrpos($_SERVER['SCRIPT_FILENAME'], '/')) . " ls-remote --get-url origin")
                  );
   }


### PR DESCRIPTION
Issue #1012 identified an issue with the command to retrieve the current branch in that it did not always get the right branch.

The ```git branch``` command retrieved all branches not just the current one.

2 solutions were identified ```git branch --contains HEAD``` and ```git rev-parse --abbrev-ref HEAD```.

I have chosen the former.